### PR TITLE
Add support to "raw" credential by environment variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 1.1.2 (2021-10-20)
+
+* Add support to GOOGLE_APPLICATION_CREDENTIALS and GOOGLE_SERVICE_ACCOUNT environment variables
+
+The GOOGLE_APPLICATION_CREDENTIALS have filename (of a file in your disk) with Service Account credentials of Google Cloud Provider, the GOOGLE_SERVICE_ACCOUNT have the content of a common credentials file, in this case you dont need store credentials file on your disk
+
 ### 1.0.2 (2021-10-20)
 
 * Minor changes about documentation

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,7 +65,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.0.2"
+version = "6.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -79,7 +79,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "google-api-core"
-version = "2.1.1"
+version = "2.2.2"
 description = "Google API client core library"
 category = "main"
 optional = false
@@ -87,13 +87,14 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 google-auth = ">=1.25.0,<3.0dev"
-googleapis-common-protos = ">=1.6.0,<2.0dev"
+googleapis-common-protos = ">=1.52.0,<2.0dev"
 grpcio = {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""}
+grpcio-status = {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""}
 protobuf = ">=3.12.0"
 requests = ">=2.18.0,<3.0.0dev"
 
 [package.extras]
-grpc = ["grpcio (>=1.33.2,<2.0dev)"]
+grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio-status (>=1.33.2,<2.0dev)"]
 grpcgcp = ["grpcio-gcp (>=0.2.2)"]
 grpcio-gcp = ["grpcio-gcp (>=0.2.2)"]
 
@@ -171,6 +172,19 @@ six = ">=1.5.2"
 
 [package.extras]
 protobuf = ["grpcio-tools (>=1.41.0)"]
+
+[[package]]
+name = "grpcio-status"
+version = "1.41.0"
+description = "Status proto mapping for gRPC"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+googleapis-common-protos = ">=1.5.5"
+grpcio = ">=1.41.0"
+protobuf = ">=3.6.0"
 
 [[package]]
 name = "idna"
@@ -368,6 +382,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-env"
+version = "0.6.2"
+description = "py.test plugin that allows you to add environment variables."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=2.6.0"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -464,7 +489,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.10"
-content-hash = "2e58c70dc97f4ecc67a3592f3d574acd847c1da267c63ea18ae6851951d913b2"
+content-hash = "2af3efd60b02e1d923b104e67b0ff1e222e5b7d5bc73c87a3a9915d57140e052"
 
 [metadata.files]
 atomicwrites = [
@@ -495,43 +520,57 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
 ]
 coverage = [
-    {file = "coverage-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd"},
-    {file = "coverage-6.0.2-cp310-cp310-win32.whl", hash = "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7"},
-    {file = "coverage-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d"},
-    {file = "coverage-6.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2"},
-    {file = "coverage-6.0.2-cp36-cp36m-win32.whl", hash = "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122"},
-    {file = "coverage-6.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9"},
-    {file = "coverage-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1"},
-    {file = "coverage-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330"},
-    {file = "coverage-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1"},
-    {file = "coverage-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb"},
-    {file = "coverage-6.0.2-cp38-cp38-win32.whl", hash = "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f"},
-    {file = "coverage-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9"},
-    {file = "coverage-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe"},
-    {file = "coverage-6.0.2-cp39-cp39-win32.whl", hash = "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce"},
-    {file = "coverage-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9"},
-    {file = "coverage-6.0.2-pp36-none-any.whl", hash = "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164"},
-    {file = "coverage-6.0.2-pp37-none-any.whl", hash = "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895"},
-    {file = "coverage-6.0.2.tar.gz", hash = "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149"},
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 google-api-core = [
-    {file = "google-api-core-2.1.1.tar.gz", hash = "sha256:646d9399c3c478fe475cfe523e84572ab31a340814ea977fb2774eca5a6549a2"},
-    {file = "google_api_core-2.1.1-py2.py3-none-any.whl", hash = "sha256:39ae7ca2208090c2942ebe1b38ca2928441a14b795c725717d38d7e30adb5fbf"},
+    {file = "google-api-core-2.2.2.tar.gz", hash = "sha256:97349cc18c2bb2415f64f1353a80273a289a61294ce3eb2f7ce682d251bdd997"},
+    {file = "google_api_core-2.2.2-py2.py3-none-any.whl", hash = "sha256:e7853735d4f51f4212d6bf9750620d76fc0106c0f271be0c3f43b73501c7ddf9"},
 ]
 google-auth = [
     {file = "google-auth-2.3.0.tar.gz", hash = "sha256:2800f6dfad29c6ced5faf9ca0c38ea8ba1ebe2559b10c029bd021e3de3301627"},
@@ -593,6 +632,10 @@ grpcio = [
     {file = "grpcio-1.41.0-cp39-cp39-win32.whl", hash = "sha256:1bcbeac764bbae329bc2cc9e95d0f4d3b0fb456b92cf12e7e06e3e860a4b31cf"},
     {file = "grpcio-1.41.0-cp39-cp39-win_amd64.whl", hash = "sha256:4537bb9e35af62c5189493792a8c34d127275a6d175c8ad48b6314cacba4021e"},
     {file = "grpcio-1.41.0.tar.gz", hash = "sha256:15c04d695833c739dbb25c88eaf6abd9a461ec0dbd32f44bc8769335a495cf5a"},
+]
+grpcio-status = [
+    {file = "grpcio-status-1.41.0.tar.gz", hash = "sha256:6e1e5221c3ca5844009bc9aca8b3bf63d1eec2b34befc380def5a704c0798399"},
+    {file = "grpcio_status-1.41.0-py3-none-any.whl", hash = "sha256:050461b69d4c835ee61ca63465d414c802bfbccc1a4017b0a3ee1991dbe7caf2"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -701,6 +744,9 @@ pytest-asyncio = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-env = [
+    {file = "pytest-env-0.6.2.tar.gz", hash = "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pydrinker_gcp/base.py
+++ b/pydrinker_gcp/base.py
@@ -1,10 +1,38 @@
+import json
+import os
+
 from google.api_core import retry
+from google.auth import jwt
 from google.cloud import pubsub_v1
+from pydrinker.exceptions import ProviderError
+
+SUB_AUDIENCE = "https://pubsub.googleapis.com/google.pubsub.v1.Subscriber"
+
+
+def _get_subscriber():
+    credential_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if credential_file and os.path.isfile(credential_file):
+        return pubsub_v1.SubscriberClient()
+
+    google_service_account = os.environ.get("GOOGLE_SERVICE_ACCOUNT")
+    if google_service_account:
+        if isinstance(google_service_account, str):
+            google_service_account = json.loads(google_service_account)
+        credentials = jwt.Credentials.from_service_account_info(
+            google_service_account,
+            audience=SUB_AUDIENCE,
+        )
+        return pubsub_v1.SubscriberClient(credentials=credentials)
+
+    raise ProviderError(
+        "cannot set subscriber without GOOGLE_APPLICATION_CREDENTIALS or "
+        "GOOGLE_SERVICE_ACCOUNT environment variables"
+    )
 
 
 class BaseSubscriber:
     def __init__(self, project_id: str, subscription_id: str, *args, **kwargs):
-        self.subscriber = pubsub_v1.SubscriberClient()
+        self.subscriber = _get_subscriber()
         self.subscription_path = self.subscriber.subscription_path(project_id, subscription_id)
 
     def get_messages(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ default_section = "THIRDPARTY"
 include_trailing_comma = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = "tests"
 addopts = "-vv --cov=pydrinker_gcp --cov-report=term-missing"
+env = "GOOGLE_APPLICATION_CREDENTIALS=\nGOOGLE_SERVICE_ACCOUNT=\n"
 
 [tool.poetry]
 name = "pydrinker-gcp"
-version = "1.0.2"
+version = "1.1.2"
 description = "Google Cloud Platform 'plugin' for pydrinker"
 authors = ["Rafael Henrique da Silva Correia <rafael@abraseucodigo.com.br>"]
 keywords = ["gcp", "consumer", "pub-sub", "google-cloud-platform", "pydrinker"]
@@ -49,6 +50,7 @@ pydrinker = "^1.0.0"
 pytest = "^6.2.5"
 pytest-asyncio = "^0.15.1"
 pytest-cov = "^3.0.0"
+pytest-env = "^0.6.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,14 +1,20 @@
+import json
+import os
 from unittest import mock
 
-from pydrinker_gcp.base import BaseSubscriber
+from pydrinker_gcp.base import SUB_AUDIENCE, BaseSubscriber, _get_subscriber
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.retry.Retry")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_get_messages_with_messages(mocked_subscriber_client, mocked_retry, pull_response):
+def test_get_messages_with_messages(
+    mocked_subscriber_client, mocked_retry, mocked_get_subscriber, pull_response
+):
     expected_deadline = 123
     expected_max_messages = 3
     mocked_subscriber_client.return_value.pull.return_value = pull_response
+    mocked_get_subscriber.return_value = mocked_subscriber_client()
 
     base_sub = BaseSubscriber(project_id="xablau-xebleu-123456", subscription_id="sample-sub")
     messages = list(base_sub.get_messages(deadline=expected_deadline, max_messages=expected_max_messages))
@@ -25,11 +31,15 @@ def test_get_messages_with_messages(mocked_subscriber_client, mocked_retry, pull
     assert received_message.message.data == b'{"xablau": "xebleu"}'
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.retry.Retry")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_get_messages_without_messages(mocked_subscriber_client, mocked_retry, pull_response):
+def test_get_messages_without_messages(
+    mocked_subscriber_client, mocked_retry, mocked_get_subscriber, pull_response
+):
     expected_deadline = 123
     expected_max_messages = 3
+    mocked_get_subscriber.return_value = mocked_subscriber_client()
 
     base_sub = BaseSubscriber(project_id="xablau-xebleu-123456", subscription_id="sample-sub")
     messages = list(base_sub.get_messages(deadline=expected_deadline, max_messages=expected_max_messages))
@@ -44,10 +54,13 @@ def test_get_messages_without_messages(mocked_subscriber_client, mocked_retry, p
     assert len(messages) == 0
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.retry.Retry")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_acknowledge_messages_call(mocked_subscriber_client, mocked_retry):
+def test_acknowledge_messages_call(mocked_subscriber_client, mocked_retry, mocked_get_subscriber):
     expected_deadline = 123
+    mocked_get_subscriber.return_value = mocked_subscriber_client()
+
     base_sub = BaseSubscriber(project_id="xablau-xebleu-123456", subscription_id="sample-sub")
     base_sub.acknowledge_messages(["xablau123"])
 
@@ -58,9 +71,59 @@ def test_acknowledge_messages_call(mocked_subscriber_client, mocked_retry):
     )
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_close_call(mocked_subscriber_client):
+def test_close_call(mocked_subscriber_client, mocked_get_subscriber):
+    mocked_get_subscriber.return_value = mocked_subscriber_client()
+
     base_sub = BaseSubscriber(project_id="xablau-xebleu-123456", subscription_id="sample-sub")
     base_sub.close()
 
     mocked_subscriber_client.return_value.close.assert_called_once_with()
+
+
+@mock.patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "credential.json"})
+@mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
+@mock.patch("pydrinker_gcp.base.os.path.isfile")
+def test_get_subscriber_with_credential_file(mocked_isfile, mocked_subscriber_client):
+    mocked_isfile.return_value = True
+    subscriber_client = _get_subscriber()
+
+    mocked_subscriber_client.assert_called_once_with()
+    assert subscriber_client == mocked_subscriber_client()
+
+
+@mock.patch("pydrinker_gcp.base.jwt.Credentials.from_service_account_info")
+@mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
+def test_get_subscriber_with_service_account_value(
+    mocked_subscriber_client, mocked_from_service_account_info
+):
+    google_service_account = (
+        '{"type": "service_account", "project_id": "fake-project-123456", "private_key_id": "123"}'
+    )
+    with mock.patch.dict(os.environ, {"GOOGLE_SERVICE_ACCOUNT": google_service_account}):
+        subscriber_client = _get_subscriber()
+
+        mocked_from_service_account_info.assert_called_once_with(
+            json.loads(google_service_account), audience=SUB_AUDIENCE
+        )
+        mocked_subscriber_client.assert_called_once_with(credentials=mocked_from_service_account_info())
+        assert subscriber_client == mocked_subscriber_client()
+
+
+@mock.patch("pydrinker_gcp.base.jwt.Credentials.from_service_account_info")
+@mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
+def test_get_subscriber_without_any_environment_variable(
+    mocked_subscriber_client, mocked_from_service_account_info
+):
+    google_service_account = (
+        '{"type": "service_account", "project_id": "fake-project-123456", "private_key_id": "123"}'
+    )
+    with mock.patch.dict(os.environ, {"GOOGLE_SERVICE_ACCOUNT": google_service_account}):
+        subscriber_client = _get_subscriber()
+
+        mocked_from_service_account_info.assert_called_once_with(
+            json.loads(google_service_account), audience=SUB_AUDIENCE
+        )
+        mocked_subscriber_client.assert_called_once_with(credentials=mocked_from_service_account_info())
+        assert subscriber_client == mocked_subscriber_client()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -114,11 +114,7 @@ def test_get_subscriber_with_service_account_value(
         assert subscriber_client == mocked_subscriber_client()
 
 
-@mock.patch("pydrinker_gcp.base.jwt.Credentials.from_service_account_info")
-@mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_get_subscriber_without_any_environment_variable(
-    mocked_subscriber_client, mocked_from_service_account_info
-):
+def test_get_subscriber_without_any_environment_variable():
     with pytest.raises(ProviderError) as exc:
         _get_subscriber()
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,10 +9,11 @@ from pydrinker_gcp.providers import SubscriptionProvider
 
 
 @pytest.mark.asyncio
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.get_messages")
 async def test_subscription_provider_fetch_messages_with_messages(
-    mocked_get_messages, mocked_subscriber_client, received_message
+    mocked_get_messages, mocked_subscriber_client, mocked_get_subscriber, received_message
 ):
     mocked_get_messages.return_value = (message for message in [received_message, received_message])
 
@@ -27,10 +28,11 @@ async def test_subscription_provider_fetch_messages_with_messages(
 
 
 @pytest.mark.asyncio
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.get_messages")
 async def test_subscription_provider_fetch_messages_without_messages(
-    mocked_get_messages, mocked_subscriber_client, received_message
+    mocked_get_messages, mocked_subscriber_client, mocked_get_subscriber, received_message
 ):
     subscription_provider = SubscriptionProvider(
         project_id="xablau-xebleu-123456", subscription_id="sample-sub", options={"some": "parameter"}
@@ -41,10 +43,11 @@ async def test_subscription_provider_fetch_messages_without_messages(
 
 
 @pytest.mark.asyncio
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.get_messages")
 async def test_subscription_provider_fetch_messages_with_timeout(
-    mocked_get_messages, mocked_subscriber_client, received_message
+    mocked_get_messages, mocked_subscriber_client, mocked_get_subscriber, received_message
 ):
     mocked_get_messages.side_effect = DeadlineExceeded(message="Deadline Exceeded")
 
@@ -60,11 +63,13 @@ async def test_subscription_provider_fetch_messages_with_timeout(
 
 
 @pytest.mark.asyncio
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.acknowledge_messages")
 async def test_subscription_provider_confirm_message_success(
     mocked_acknowledge_messages,
     mocked_subscriber_client,
+    mocked_get_subscriber,
     received_message,
 ):
     subscription_provider = SubscriptionProvider(
@@ -75,10 +80,11 @@ async def test_subscription_provider_confirm_message_success(
 
 
 @pytest.mark.asyncio
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.acknowledge_messages")
 async def test_subscription_provider_confirm_message_with_timeout(
-    mocked_acknowledge_messages, mocked_subscriber_client, received_message
+    mocked_acknowledge_messages, mocked_subscriber_client, mocked_get_subscriber, received_message
 ):
     mocked_acknowledge_messages.side_effect = DeadlineExceeded(message="Deadline Exceeded")
 
@@ -92,9 +98,10 @@ async def test_subscription_provider_confirm_message_with_timeout(
     mocked_acknowledge_messages.assert_called_once_with(ack_ids=["123abc"], some="parameter")
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
 @mock.patch("pydrinker_gcp.providers.BaseSubscriber.close")
-def test_subscription_provider_stop_success(mocked_close, mocked_subscriber_client):
+def test_subscription_provider_stop_success(mocked_close, mocked_subscriber_client, mocked_get_subscriber):
     subscription_provider = SubscriptionProvider(
         project_id="xablau-xebleu-123456", subscription_id="sample-sub", options={"some": "parameter"}
     )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -6,8 +6,9 @@ from pydrinker_gcp.message_translators import SubscriptionMessageTranslator
 from pydrinker_gcp.routes import SubscriptionRoute
 
 
+@mock.patch("pydrinker_gcp.base._get_subscriber")
 @mock.patch("pydrinker_gcp.base.pubsub_v1.SubscriberClient")
-def test_subscription_route_instance(mocked_subscriber_client):
+def test_subscription_route_instance(mocked_subscriber_client, mocked_get_subscriber):
     def fake_function(message, *args):
         pass
 


### PR DESCRIPTION
#### What does this PR do?
Add support to GOOGLE_APPLICATION_CREDENTIALS and GOOGLE_SERVICE_ACCOUNT environment variables.

#### Why is it necessary?
The GOOGLE_APPLICATION_CREDENTIALS have filename (of a file in your disk) with Service Account credentials of Google Cloud Provider, the GOOGLE_SERVICE_ACCOUNT have the content of a common credentials file, in this case, you don't need store credentials file on your disk.

#### Examples:

To start a consumer you can do:
```
GOOGLE_APPLICATION_CREDENTIALS="credentials.json" python -m consumer
```

Or:
```
GOOGLE_SERVICE_ACCOUNT='{"type": "service_account", "project_id": "fake-project-123456", "private_key_id": "123"}' python -m consumer
```

PS: This Google Service Account is invalid, is only an example.